### PR TITLE
Add go example to the test-summary examples

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,5 +1,7 @@
 name: Examples
 
+#dummy
+
 on:
   push:
     branches: [ main ]
@@ -45,6 +47,31 @@ jobs:
         uses: test-summary/action@v1
         with:
           paths: dotnet/results/**/*.xml
+        if: always()
+
+  go-junit:
+    name: Go / JUnit
+    runs-on: ubuntu-latest
+    env:
+      EXAMPLE_PATH: "go-junit"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Build the code
+        working-directory: ${{ env.EXAMPLE_PATH }}
+        run: |
+          go build .
+      - name: Run the tests
+        working-directory: ${{ env.EXAMPLE_PATH }}
+        run: |
+          export GOPATH="$HOME/go/"
+          export PATH=$PATH:$GOPATH/bin
+          go install github.com/jstemmer/go-junit-report@latest
+          go test -v ./... | go-junit-report -set-exit-code > report.xml
+      - name: Create test summary
+        uses: test-summary/action@dist
+        with:
+          paths: ${{ env.EXAMPLE_PATH }}/report.xml
         if: always()
 
   # This runs Java tests using the JUnit test framework

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Some example projects to show how to emit test output in various types of projec
 Examples:
 
 * [C with the Clar test framework](c-clar/)
+* [Go with the JUnit test framework](go-junit/)
 * [Java with the JUnit test framework](java-junit/)
 * [JavaScript with the mocha test framework](javascript-mocha/)
 * [JavaScript with the node-tap test framework](javascript-tap/)

--- a/go-junit/README.md
+++ b/go-junit/README.md
@@ -1,0 +1,51 @@
+test-summary example: Go with JUnit
+=====================================
+
+This produces a test summary for a Go module using the JUnit test framework.
+
+To output a native Go test into a JUnit compatible XML file, you will need to use an additional package. [go-junit-report](https://github.com/jstemmer/go-junit-report) is one such package that can be used to generate a JUnit compatible XML file from a Go test output.
+
+The sample go module is based on the documentation from the [Go tutorial docs](https://go.dev/doc/tutorial/add-a-test).
+
+GitHub Actions Workflow
+-----------------------
+
+An example GitHub Actions workflow that builds a Go project, runs the tests and converts them using the go-junit-report, then runs the test-summary action and uploads the test summary markdown as an artifact.
+
+```yaml
+name: Build and Test Go with JUnit
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+env:
+  EXAMPLE_PATH: "go-junit"
+
+jobs:
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Build the code
+        working-directory: ${{ env.EXAMPLE_PATH }}
+        run: |
+          go build .
+      - name: Run the tests
+        working-directory: ${{ env.EXAMPLE_PATH }}
+        run: |
+          export GOPATH="$HOME/go/"
+          export PATH=$PATH:$GOPATH/bin
+          go install github.com/jstemmer/go-junit-report@latest
+          go test -v ./... | go-junit-report -set-exit-code > report.xml
+      - name: Create test summary
+        uses: test-summary/action@dist
+        with:
+          paths: ${{ env.EXAMPLE_PATH }}/report.xml
+        if: always()
+```

--- a/go-junit/go.mod
+++ b/go-junit/go.mod
@@ -1,0 +1,3 @@
+module example.com
+
+go 1.18

--- a/go-junit/greetings/greetings.go
+++ b/go-junit/greetings/greetings.go
@@ -1,0 +1,39 @@
+package greetings
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+// Hello returns a greeting for the named person.
+func Hello(name string) (string, error) {
+	// If no name was given, return an error with a message.
+	if name == "" {
+		return name, errors.New("empty name")
+	}
+	// Create a message using a random format.
+	message := fmt.Sprintf(randomFormat(), name)
+	return message, nil
+}
+
+// init sets initial values for variables used in the function.
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+// randomFormat returns one of a set of greeting messages. The returned
+// message is selected at random.
+func randomFormat() string {
+	// A slice of message formats.
+	formats := []string{
+		"Hi, %v. Welcome!",
+		"Great to see you, %v!",
+		"Hail, %v! Well met!",
+	}
+
+	// Return a randomly selected message format by specifying
+	// a random index for the slice of formats.
+	return formats[rand.Intn(len(formats))]
+}

--- a/go-junit/greetings/greetings_test.go
+++ b/go-junit/greetings/greetings_test.go
@@ -1,0 +1,26 @@
+package greetings
+
+import (
+	"regexp"
+	"testing"
+)
+
+// TestHelloName calls greetings.Hello with a name, checking
+// for a valid return value.
+func TestHelloName(t *testing.T) {
+	name := "Ed"
+	want := regexp.MustCompile(`\b` + name + `\b`)
+	msg, err := Hello("Chris")
+	if !want.MatchString(msg) || err != nil {
+		t.Fatalf(`Hello("Chris") = %q, %v, want match for %#q, nil`, msg, err, want)
+	}
+}
+
+// TestHelloEmpty calls greetings.Hello with an empty string,
+// checking for an error.
+func TestHelloEmpty(t *testing.T) {
+	msg, err := Hello("")
+	if msg != "" || err == nil {
+		t.Fatalf(`Hello("") = %q, %v, want "", error`, msg, err)
+	}
+}

--- a/go-junit/main.go
+++ b/go-junit/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"example.com/greetings"
+)
+
+func main() {
+	// Set properties of the predefined Logger, including
+	// the log entry prefix and a flag to disable printing
+	// the time, source file, and line number.
+	log.SetPrefix("greetings: ")
+	log.SetFlags(0)
+
+	// Request a greeting message.
+	message, err := greetings.Hello("Gladys")
+	// If an error was returned, print it to the console and
+	// exit the program.
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// If no error was returned, print the returned message
+	// to the console.
+	fmt.Println(message)
+}


### PR DESCRIPTION
This Pull Request provides an example of using the [test-summary/action GitHub Action](https://github.com/test-summary/action) to test a Go project.

This example -

* Uses the [go.dev Testing tutorial](https://go.dev/doc/tutorial/add-a-test) as a basis for the code sample.
* Uses the [go-junit-report package](https://github.com/jstemmer/go-junit-report) to convert the native Go test output to a JUnit format, as required by the test-summary/action GitHub Action.

Any questions, or tweaks needed - please let me know!